### PR TITLE
fix article link clickable area

### DIFF
--- a/public/blog/index.css
+++ b/public/blog/index.css
@@ -12,6 +12,7 @@
 
 .card {
     display: block;
+    position: relative;
     list-style: none;
     padding: 1em;
     margin: 0 -1em;


### PR DESCRIPTION
Hi, I found a strange behavior of links in blog cards. The pseudo element was not expanding correctly. The `position: relative` in the card fixes this and makes the clickable area correct.