### PR TITLE
Moving all script tags into head with defer attribute

### DIFF
--- a/public/pages/components.html
+++ b/public/pages/components.html
@@ -202,7 +202,7 @@
                 <p>
                     If you've paid close attention, you have seen that we're using the <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules">ES module syntax</a> for <code>import</code> and <code>export</code> in our code,
                     but we haven't set up any JavaScript bundler to transpile that syntax. The magic that makes this work is in the <code>index.html</code>,
-                    where the <code>&lt;script type="module" src="index.js"&gt;</code> tag's type attribute enables ES module mode for all the included JavaScript.
+                    where the <code>&lt;script type="module" src="index.js" defer&gt;</code> tag's type attribute enables ES module mode for all the included JavaScript.
                     This is supported by all modern browsers.
                 </p>
             </aside>

--- a/public/pages/examples/applications/counter/index.html
+++ b/public/pages/examples/applications/counter/index.html
@@ -5,9 +5,9 @@
         body { font-family: system-ui, sans-serif; }
         x-counter { color: red; }
     </style>
+    <script type="module" src="index.js" defer></script>
 </head>
 <body>
-    <script type="module" src="index.js"></script>
     <p>Let's count to <x-counter></x-counter>.</p>
     <button onclick="document.querySelector('x-counter').increment()">
         Increment

--- a/public/pages/examples/applications/lifting-state-up/index.html
+++ b/public/pages/examples/applications/lifting-state-up/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
     <link rel="stylesheet" href="index.css">
+    <script type="module" src="index.js" defer></script>
 </head>
 <body>
-    <script type="module" src="index.js"></script>
     <x-accordion></x-accordion>
 </body>
 </html>

--- a/public/pages/examples/applications/passing-data-deeply/index.html
+++ b/public/pages/examples/applications/passing-data-deeply/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
     <link rel="stylesheet" href="index.css">
+    <script type="module" src="index.js" defer></script>
 </head>
 <body>
-    <script type="module" src="index.js"></script>
     <x-theme-context>
         <x-panel title="Welcome">
             <x-button>Toggle theme</x-button>

--- a/public/pages/examples/applications/single-page/index.html
+++ b/public/pages/examples/applications/single-page/index.html
@@ -3,12 +3,12 @@
 <head>
     <title>Single-page Example</title>
     <link rel="stylesheet" href="index.css">
+    <script type="module" src="index.js" defer></script>
 </head>
 <body>
     <noscript><strong>Please enable JavaScript to view this page.</strong></noscript>
     <template id="root">
         <x-app></x-app>
     </template>
-    <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/public/pages/examples/components/adding-children/index.html
+++ b/public/pages/examples/components/adding-children/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
     <link rel="stylesheet" href="index.css">
+    <script type="module" src="index.js" defer></script>
 </head>
 <body>
-    <script type="module" src="index.js"></script>
     <p>Avatar and badge, when their powers combine...</p>
     <div>
         <x-badge content="5" id="live-badge">

--- a/public/pages/examples/components/advanced/index.html
+++ b/public/pages/examples/components/advanced/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
     <link rel="stylesheet" href="index.css">
+    <script type="module" src="index.js" defer></script>
 </head>
 <body>
-    <script type="module" src="index.js"></script>
     <p>A basic avatar component in two sizes:</p>
     <x-avatar src="https://i.pravatar.cc/150?u=a042581f4e29026024d"></x-avatar>
     <x-avatar src="https://i.pravatar.cc/150?u=a04258114e29026302d" size="lg"></x-avatar>

--- a/public/pages/examples/components/data/index.html
+++ b/public/pages/examples/components/data/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
     <link rel="stylesheet" href="index.css">
+    <script type="module" src="index.js" defer></script>
 </head>
 <body>
-    <script type="module" src="index.js"></script>
     <santas-app></santas-app>
 </body>
 </html>

--- a/public/pages/examples/components/shadow-dom/index.html
+++ b/public/pages/examples/components/shadow-dom/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <link rel="stylesheet" href="index.css">
+    <script type="module" src="index.js" defer></script>
 </head>
 <body>
     <x-header title="Welcome">
@@ -12,6 +13,5 @@
     <main>
         <p>Hello, shadow DOM!</p>
     </main>
-    <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/public/pages/examples/components/simple/index.html
+++ b/public/pages/examples/components/simple/index.html
@@ -1,7 +1,9 @@
 <!doctype html>
 <html lang="en">
+<head>
+    <script src="hello-world.js" defer></script>
+</head>
 <body>
-    <script src="hello-world.js"></script>
     <p>I just want to say...</p>
     <x-hello-world></x-hello-world>
 </body>

--- a/public/pages/examples/sites/importmap/index.html
+++ b/public/pages/examples/sites/importmap/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <link rel="stylesheet" href="index.css">
-    <script src="./lib/dayjs/dayjs.min.js"></script>
-    <script src="./lib/dayjs/relativeTime.js"></script>
+    <script src="./lib/dayjs/dayjs.min.js" defer></script>
+    <script src="./lib/dayjs/relativeTime.js" defer></script>
     <script type="importmap">
         {
             "imports": {
@@ -12,9 +12,9 @@
             }
         }
     </script>
+    <script type="module" src="index.js" defer></script>
 </head>
 <body>
-    <script type="module" src="index.js"></script>
     <x-metrics></x-metrics>
 </body>
 </html>

--- a/public/pages/examples/sites/imports/index.html
+++ b/public/pages/examples/sites/imports/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <link rel="stylesheet" href="index.css">
+    <script src="./lib/dayjs/dayjs.min.js" defer></script>
+    <script src="./lib/dayjs/relativeTime.js" defer></script>
+    
+    <script type="module" src="index.js" defer></script>
 </head>
 <body>
-    <script src="./lib/dayjs/dayjs.min.js"></script>
-    <script src="./lib/dayjs/relativeTime.js"></script>
-
-    <script type="module" src="index.js"></script>
     <x-metrics></x-metrics>
 </body>
 </html>

--- a/public/pages/examples/sites/page/example.html
+++ b/public/pages/examples/sites/page/example.html
@@ -5,6 +5,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" href="index.css">
+        <script type="module" src="index.js" defer></script>
     </head>
     <body>
         <noscript><strong>Please enable JavaScript to view this page correctly.</strong></noscript>
@@ -17,6 +18,5 @@
         <footer>
             byline and copyright ...
         </footer>    
-        <script type="module" src="index.js"></script>
     </body>
 </html>

--- a/public/pages/examples/sites/page/example2.html
+++ b/public/pages/examples/sites/page/example2.html
@@ -5,6 +5,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" href="index.css">
+        <script type="module" src="index.js" defer></script>
     </head>
     <body>
         <noscript><strong>Please enable JavaScript to view this page.</strong></noscript>
@@ -19,6 +20,5 @@
                 byline and copyright ...
             </footer>    
         </template>
-        <script type="module" src="index.js"></script>
     </body>
 </html>

--- a/public/pages/examples/styling/scoping-prefixed/index.html
+++ b/public/pages/examples/styling/scoping-prefixed/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
     <link rel="stylesheet" href="index.css">
+    <script type="module" src="index.js" defer></script>
 </head>
 <body>
     <x-example></x-example>
     <p>This &lt;p&gt; is not affected, because it is outside the custom element.</p>
-    <script type="module" src="index.js"></script>
 </html>

--- a/public/pages/examples/styling/scoping-shadowed/index.html
+++ b/public/pages/examples/styling/scoping-shadowed/index.html
@@ -1,9 +1,11 @@
 <!doctype html>
 <html lang="en">
+<head>
+    <script type="module" src="index.js" defer></script>
+</head>    
 <body>
     <x-example>
         <p>This &lt;p&gt; is not affected, even though it is slotted.</p>
     </x-example>
-    <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/public/pages/sites.html
+++ b/public/pages/sites.html
@@ -49,12 +49,12 @@
                 <dd>The viewport meta is necessary to have mobile-friendly layout.</dd>
                 <dt><code>&lt;head&gt;&lt;link rel="stylesheet" href="index.css"&gt;</code></dt>
                 <dd>By convention the stylesheet is loaded from <code>&lt;head&gt;</code> in a blocking way to ensure the page's markup does not have a flash of unstyled content.</dd>
+                <dt><code>&lt;head&gt;&lt;script type="module" src="index.js" defer&gt;</code></dt>
+                <dd>The main JavaScript file is in the <code>&lt;head&gt;</code>, and will bootstrap the web components as explained on the components page.</dd>
                 <dt><code>&lt;body&gt;&lt;noscript&gt;</code></dt>
                 <dd>Because web components don't work without JavaScript it is good practice to include a noscript warning to users that have JavaScript disabled. This warning only needs to be on pages with web components. If you don't want to show anything except the warning, see the template pattern below.</dd>
                 <dt><code>&lt;body&gt;&lt;header/main/footer&gt;</code></dt>
                 <dd>The page's markup should be organized using <a href="https://developer.mozilla.org/en-US/blog/aria-accessibility-html-landmark-roles/">HTML landmarks</a>. Landmarks when used properly help organize the page into logical blocks and make the page's structure accessible. Because they are standards-based, compatibility with present and future accessibility products is more likely.</dd>
-                <dt><code>&lt;body&gt;&lt;script type="module" src="index.js"&gt;</code></dt>
-                <dd>The main JavaScript file is at the end, and will bootstrap the web components as explained on the components page.</dd>
             </dl>
             <p>
                 Pages that should only show their contents if JavaScript is enabled can use this template pattern:

--- a/public/tests/index.html
+++ b/public/tests/index.html
@@ -8,24 +8,24 @@
     <!-- https://unpkg.com/mocha@9.2.2/mocha.css -->
     <link rel="stylesheet" href="./lib/mocha/mocha.css" />
     <!-- https://unpkg.com/chai@4.3.6/chai.js -->
-    <script src="./lib/mocha/chai.js"></script>
+    <script src="./lib/mocha/chai.js" defer></script>
     <!-- https://unpkg.com/mocha@9.2.2/mocha.js -->
-    <script src="./lib/mocha/mocha.js"></script>
+    <script src="./lib/mocha/mocha.js" defer></script>
     <!-- https://unpkg.com/@testing-library/dom@8.17.1/dist/@testing-library/dom.umd.js -->
-    <script src="./lib/@testing-library/dom.umd.js"></script>
-</head>
-<body>
-    <div id="mocha"></div>
-
-    <script type="module" class="mocha-init">
+    <script src="./lib/@testing-library/dom.umd.js" defer></script>
+    
+    <script type="module" class="mocha-init" defer>
         mocha.setup('bdd');
         mocha.checkLeaks();
     </script>
-
-    <script type="module" src="./tabpanel.test.js"></script>
+    
+    <script type="module" src="./tabpanel.test.js" defer></script>
     
     <!-- include more tests here -->
-
-    <script type="module" class="mocha-exec" src="./index.js"></script>
+    
+    <script type="module" class="mocha-exec" src="./index.js" defer></script>
+</head>
+<body>
+    <div id="mocha"></div>
 </body>
 </html>


### PR DESCRIPTION
As discussed by email, it's best to use `defer` attribute on script tags and put them into the `head` section to boost performances (they're downloaded in parallel and don't halt HTML parsing).

All modified examples have been tested, it was easy as you use the exact content of files through iframes!
The tests for x-tab-panel with mocha works too.

I modified the **public/pages/sites.html** content to reflect the position change of the script into the head and not the body anymore.

Last point, I just modified the examples, not the core code of your website but I can upgrade it if you want too.